### PR TITLE
모임 서비스 테스트

### DIFF
--- a/src/main/java/com/onmoim/server/config/AsyncConfig.java
+++ b/src/main/java/com/onmoim/server/config/AsyncConfig.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -18,16 +17,15 @@ public class AsyncConfig {
 	@Bean(name = "MapApiExecutor")
 	public Executor kakaoApiExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(5);      // default 스레드 수
-		executor.setMaxPoolSize(10);      // 최대 스레드 수
-		executor.setQueueCapacity(100);   // 대기 큐 크기
-		executor.setKeepAliveSeconds(60); // 60초
+		executor.setCorePoolSize(32);              // default 스레드 수
+		executor.setMaxPoolSize(32);               // 최대 스레드 수
+		executor.setQueueCapacity(1000000);        // 대기 큐 크기
 		executor.setThreadNamePrefix("MapApiExecutor-");
 		executor.setRejectedExecutionHandler(new MapPolicy());
 		executor.initialize();
+		executor.getThreadPoolExecutor().prestartAllCoreThreads(); // 요청 이전에 미리 스레드 생성
 		return executor;
 	}
-
 	private static class MapPolicy extends CallerRunsPolicy {
 		private MapPolicy() {}
 		@Override

--- a/src/main/java/com/onmoim/server/group/entity/Status.java
+++ b/src/main/java/com/onmoim/server/group/entity/Status.java
@@ -11,6 +11,7 @@ public enum Status {
 	OWNER("모임장"),
 	MEMBER("회원"),
 	BOOKMARK("북마크"),
-	BAN("차단");
+	BAN("차단"),
+	DELETED("삭제");
 	private final String description;
 }


### PR DESCRIPTION
## 모임 서비스 테스트

---

## 🛰️ Issue Number


---
## 🪐 작업 내용
- 비동기 스레드 풀 설정
- 탈퇴 상태 추가
- 모임 서비스 관련 테스트
   - 동시성 테스트: 각 스레드 트랜잭션 분리를 위해서 명시적으로 cleanup 
   - 나머지 일반 테스트: @Transactional 통해서 자동 롤백 

---

## 🧐 리뷰 시 중점적으로 봐주셨으면 하는 부분
- @dbkoo 현재 모임 서비스에서는 모임 탈퇴 또는 좋아요 취소 이후 임시 상태(PENDING)를 가지는데 탈퇴한 회원으로 soft delete 처리 시
    DELETED 상태로 바꿔주세요 + base Entity deleted At 업데이트 포함입니다! 

---
## 🧪 테스트 


---
## 📚 Reference

---
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

---
### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)