### PR TITLE
[Auth] 카카오 로그인 로직 수정

### DIFF
--- a/src/main/java/com/onmoim/server/config/RedisConfig.java
+++ b/src/main/java/com/onmoim/server/config/RedisConfig.java
@@ -20,12 +20,23 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
+	@Value("${spring.profiles.active}")
+	private String activeProfile;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
-		LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
-			.useSsl()
-			.build();
+		LettuceClientConfiguration clientConfig;
+
+		if (isSslEnabled()) {
+			clientConfig = LettuceClientConfiguration.builder()
+				.useSsl()
+				.build();
+		} else {
+			clientConfig = LettuceClientConfiguration.builder()
+				.build();
+		}
+
 		return new LettuceConnectionFactory(config, clientConfig);
 	}
 
@@ -45,4 +56,9 @@ public class RedisConfig {
 
 		return redisTemplate;
 	}
+
+	private boolean isSslEnabled() {
+		return "dev".equals(activeProfile); // dev에서만 SSL 사용
+	}
+
 }

--- a/src/main/java/com/onmoim/server/oauth/controller/AuthController.java
+++ b/src/main/java/com/onmoim/server/oauth/controller/AuthController.java
@@ -1,5 +1,8 @@
 package com.onmoim.server.oauth.controller;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -68,12 +71,12 @@ public class AuthController {
 		OAuthResponseDto response = new OAuthResponseDto();
 
 		String provider = request.getProvider();
-		String code = request.getAuthorizationCode();
+		String token = request.getToken();
 
 		if (provider.equals("google")) {
-			response = oAuthService.handleGoogleLogin(provider, code);
+			response = oAuthService.handleGoogleLogin(provider, token);
 		} else {
-			response = oAuthService.handleKakaoLogin(provider, code);
+			response = oAuthService.handleKakaoLogin(provider, token);
 		}
 
 		return ResponseEntity.ok(ResponseHandler.response(response));

--- a/src/main/java/com/onmoim/server/oauth/dto/OAuthRequestDto.java
+++ b/src/main/java/com/onmoim/server/oauth/dto/OAuthRequestDto.java
@@ -11,7 +11,7 @@ public class OAuthRequestDto {
 	@Pattern(regexp = "^(google|kakao)$", message = "provider는 google 또는 kakao만 가능합니다.")
 	private String provider;
 
-	@Schema(description = "authorization code")
-	private String authorizationCode;
+	@Schema(description = "구글: idToken, 카카오: accessToken")
+	private String token;
 
 }

--- a/src/main/java/com/onmoim/server/oauth/service/OAuthService.java
+++ b/src/main/java/com/onmoim/server/oauth/service/OAuthService.java
@@ -4,9 +4,9 @@ import com.onmoim.server.oauth.dto.OAuthResponseDto;
 
 public interface OAuthService {
 
-	OAuthResponseDto handleGoogleLogin(String providerName, String authorizationCode);
+	OAuthResponseDto handleGoogleLogin(String providerName, String token);
 
-	OAuthResponseDto handleKakaoLogin(String providerName, String authorizationCode);
+	OAuthResponseDto handleKakaoLogin(String providerName, String token);
 
 	OAuthResponseDto reissueAccessToken(String refreshToken);
 

--- a/src/main/java/com/onmoim/server/oauth/service/impl/OAuthServiceImpl.java
+++ b/src/main/java/com/onmoim/server/oauth/service/impl/OAuthServiceImpl.java
@@ -32,24 +32,22 @@ import lombok.extern.slf4j.Slf4j;
 public class OAuthServiceImpl implements OAuthService {
 
 	private final OAuthProviderFactory oauthProviderFactory;
-	private final GoogleOAuthProvider googleProvider;
-	// private final KakaoOAuthProvider kakaoProvider;
 	private final UserRepository userRepository;
 	private final JwtProvider jwtProvider;
 	private final RefreshTokenService refreshTokenService;
 
 	@Override
-	public OAuthResponseDto handleGoogleLogin(String providerName, String authorizationCode) {
+	public OAuthResponseDto handleGoogleLogin(String providerName, String token) {
 		OAuthProvider provider = oauthProviderFactory.getProvider(providerName);
-		OAuthUserDto oAuthUserDto = provider.getUserInfoByAuthorizationCode(authorizationCode);
+		OAuthUserDto oAuthUserDto = provider.getUserInfoByToken(token);
 
 		return processUserLogin(oAuthUserDto, providerName);
 	}
 
 	@Override
-	public OAuthResponseDto handleKakaoLogin(String providerName, String authorizationCode) {
+	public OAuthResponseDto handleKakaoLogin(String providerName, String token) {
 		OAuthProvider provider = oauthProviderFactory.getProvider(providerName);
-		OAuthUserDto oAuthUserDto = provider.getUserInfoByAuthorizationCode(authorizationCode);
+		OAuthUserDto oAuthUserDto = provider.getUserInfoByToken(token);
 
 		return processUserLogin(oAuthUserDto, providerName);
 	}

--- a/src/main/java/com/onmoim/server/oauth/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/onmoim/server/oauth/service/impl/RefreshTokenServiceImpl.java
@@ -24,11 +24,21 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 		String key = getKey(userId);
 		log.info("Redis 저장 시작: key={}, value={}", key, refreshToken);
 
-		redisTemplate.opsForValue().set(
-			key,
-			refreshToken,
-			Duration.ofMillis(tokenProperties.getRefreshExpirationTime())
-		);
+		try {
+			redisTemplate.opsForValue().set(
+				key,
+				refreshToken,
+				Duration.ofMillis(tokenProperties.getRefreshExpirationTime())
+			);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		// redisTemplate.opsForValue().set(
+		// 	key,
+		// 	refreshToken,
+		// 	Duration.ofMillis(tokenProperties.getRefreshExpirationTime())
+		// );
 
 		log.info("Redis 저장 완료: key={}", key);
 	}

--- a/src/main/java/com/onmoim/server/oauth/service/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/onmoim/server/oauth/service/provider/GoogleOAuthProvider.java
@@ -50,7 +50,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
 	}
 
 	@Override
-	public OAuthUserDto getUserInfoByAuthorizationCode(String code) {
+	public OAuthUserDto getUserInfoByToken(String code) {
 
 		try {
 			// 1. Authorization Code로 Access Token 요청

--- a/src/main/java/com/onmoim/server/oauth/service/provider/OAuthProvider.java
+++ b/src/main/java/com/onmoim/server/oauth/service/provider/OAuthProvider.java
@@ -6,6 +6,6 @@ public interface OAuthProvider {
 
 	String getProviderName();
 
-	OAuthUserDto getUserInfoByAuthorizationCode(String code);
+	OAuthUserDto getUserInfoByToken(String token);
 
 }

--- a/src/main/java/com/onmoim/server/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/onmoim/server/user/service/impl/UserServiceImpl.java
@@ -23,7 +23,6 @@ import com.onmoim.server.group.entity.Status;
 import com.onmoim.server.group.repository.GroupUserRepository;
 import com.onmoim.server.oauth.dto.OAuthUserDto;
 import com.onmoim.server.oauth.service.RefreshTokenService;
-import com.onmoim.server.security.CustomUserDetails;
 import com.onmoim.server.security.JwtHolder;
 import com.onmoim.server.security.JwtProvider;
 import com.onmoim.server.user.dto.request.CreateUserCategoryRequestDto;


### PR DESCRIPTION
## [Auth] 카카오 로그인 로직 수정

---

## 🛰️ Issue Number


---
## 🪐 작업 내용
- 카카오 로그인 로직 수정(프론트에서 authorizationCode -> accessToken 받는 로직으로 변경)

---

## 🧐 리뷰 시 중점적으로 봐주셨으면 하는 부분
> 기존 authorizationCode를 받아 카카오 api로 accessToken을 요청하는 부분을 삭제하고, 프론트에서 accessToken을 받아 userInfo만 요청하도록 수정하였습니다.

---
## 🧪 테스트 
> 테스트 후 공유할 만한 사항이 있다면 스크린샷으로 남갸주세요!


---
## 📚 Reference

---
## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

---
### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)