### PR TITLE
[Meeting] 다가오는 일정 조회 모임 id 파라미터 추가

### DIFF
--- a/src/main/java/com/onmoim/server/meeting/dto/request/UpcomingMeetingsRequestDto.java
+++ b/src/main/java/com/onmoim/server/meeting/dto/request/UpcomingMeetingsRequestDto.java
@@ -30,4 +30,7 @@ public class UpcomingMeetingsRequestDto {
 	@Schema(description = "번개모임")
 	private Boolean flashYn;
 
+	@Schema(description = "모임 id")
+	private Long groupId;
+
 }

--- a/src/main/java/com/onmoim/server/meeting/repository/MeetingRepositoryCustomImpl.java
+++ b/src/main/java/com/onmoim/server/meeting/repository/MeetingRepositoryCustomImpl.java
@@ -276,6 +276,11 @@ public class MeetingRepositoryCustomImpl implements MeetingRepositoryCustom {
 			where.and(meeting.type.eq(MeetingType.FLASH));
 		}
 
+		// 모임 id로 필터링 추가
+		if (request.getGroupId() != null) {
+			where.and(meeting.group.id.eq(request.getGroupId()));
+		}
+
 		return where;
 	}
 


### PR DESCRIPTION
## [Meeting] 다가오는 일정 조회 모임 id 파라미터 추가

---

## 🛰️ Issue Number


---
## 🪐 작업 내용
- 다가오는 일정 조회 시 모임 id 파라미터 추가
- MeetingQueryServiceTest baseTime 수정

---

## 🧐 리뷰 시 중점적으로 봐주셨으면 하는 부분
> 리뷰어가 집중해서 보면 좋을 코드 섹션이나 로직이 있다면 설명해 주세요.

---
## 🧪 테스트 
> 테스트 후 공유할 만한 사항이 있다면 스크린샷으로 남갸주세요!


---
## 📚 Reference

---
## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

---
### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)